### PR TITLE
Hide outline on focussed result

### DIFF
--- a/search_results.css
+++ b/search_results.css
@@ -1,5 +1,6 @@
 .highlighted-search-result {
   /* background-color: rgba(255, 49, 49, 0.3); */
+  outline: none;
 }
 
 .highlighted-search-result::before {


### PR DESCRIPTION
Hides the ugly blue (Mac) or dotted (Windows) box on the focussed search result