### PR TITLE
Firefox popup blocker preventing new tab

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,9 +70,7 @@ Object.assign(extension, {
     });
     this.register(options.navigateNewTabKey, () => {
       const link = results.items[results.focusedIndex];
-      // NOTE: Firefox (tested in 58) somehow from single window.open() opened
-      // a link twice. Using timeout solves the issue.
-      window.setTimeout(() => window.open(link.anchor.href));
+      browser.runtime.sendMessage({type: 'tabsCreate', options: {url: link.anchor.href, active: true}});
     });
     this.register(options.navigateNewTabBackgroundKey, () => {
       const link = results.items[results.focusedIndex];


### PR DESCRIPTION
Firefox popup blocker is interfering with the tab created by `window.open` ("Open in a new window/tab" action on ctrl+shift+enter).

Affects Firefox v62. No problem in other browsers.