### PR TITLE
Add bindings to focus results 1-10 on page

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -8,6 +8,18 @@ const extension = {
       autoSelectFirst: true,
       nextKey: 'down, j',
       previousKey: 'up, k',
+      focusSpecificResult: [
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10'
+      ],
       navigatePreviousResultPage: 'left, h',
       navigateNextResultPage: 'right, l',
       navigateKey: 'return, space',

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,11 @@ Object.assign(extension, {
         results.focusPrevious(options.wrapNavigation);
       }
     });
+    options.focusSpecificResult.forEach((focusNthResult, index) => {
+      this.register(focusNthResult, () => {
+        results.focus(index);
+      });
+    });
     this.register(options.navigateKey, () => {
       const link = results.items[results.focusedIndex];
       lastNavigation.lastQueryUrl = location.href;

--- a/src/options.html
+++ b/src/options.html
@@ -134,6 +134,46 @@
             <label for="toggle-sort" class="option-desc">Toggle sort by date/relevance</label>
             <input id="toggle-sort" class="input-keybinding" type="text" value="ctrl+shift+s">
         </div>
+        <div class="option">
+            <label for="focus-0th-result" class="option-desc">Focus 1st result on page</label>
+            <input id="focus-0th-result" class="input-keybinding" type="text" value="1">
+        </div>
+        <div class="option">
+            <label for="focus-1th-result" class="option-desc">Focus 2nd result on page</label>
+            <input id="focus-1th-result" class="input-keybinding" type="text" value="2">
+        </div>
+        <div class="option">
+            <label for="focus-2th-result" class="option-desc">Focus 3rd result on page</label>
+            <input id="focus-2th-result" class="input-keybinding" type="text" value="3">
+        </div>
+        <div class="option">
+            <label for="focus-3th-result" class="option-desc">Focus 4th result on page</label>
+            <input id="focus-3th-result" class="input-keybinding" type="text" value="4">
+        </div>
+        <div class="option">
+            <label for="focus-4th-result" class="option-desc">Focus 5th result on page</label>
+            <input id="focus-4th-result" class="input-keybinding" type="text" value="5">
+        </div>
+        <div class="option">
+            <label for="focus-5th-result" class="option-desc">Focus 6th result on page</label>
+            <input id="focus-5th-result" class="input-keybinding" type="text" value="6">
+        </div>
+        <div class="option">
+            <label for="focus-6th-result" class="option-desc">Focus 7th result on page</label>
+            <input id="focus-6th-result" class="input-keybinding" type="text" value="7">
+        </div>
+        <div class="option">
+            <label for="focus-7th-result" class="option-desc">Focus 8th result on page</label>
+            <input id="focus-7th-result" class="input-keybinding" type="text" value="8">
+        </div>
+        <div class="option">
+            <label for="focus-8th-result" class="option-desc">Focus 9th result on page</label>
+            <input id="focus-8th-result" class="input-keybinding" type="text" value="9">
+        </div>
+        <div class="option">
+            <label for="focus-9th-result" class="option-desc">Focus 10th result on page</label>
+            <input id="focus-9th-result" class="input-keybinding" type="text" value="0">
+        </div>
     </div>
 
     <div id="status"></div>

--- a/src/options.js
+++ b/src/options.js
@@ -16,11 +16,20 @@ const saveOptions = () => {
     autoSelectFirst: document.getElementById('auto-select-first').checked,
     nextKey: document.getElementById('next-key').value,
     previousKey: document.getElementById('previous-key').value,
-    navigatePreviousResultPage: document.getElementById(
-      'navigate-previous-result-page'
-    ).value,
-    navigateNextResultPage: document.getElementById('navigate-next-result-page')
-      .value,
+    focusSpecificResult: [
+      document.getElementById('focus-0th-result').value,
+      document.getElementById('focus-1th-result').value,
+      document.getElementById('focus-2th-result').value,
+      document.getElementById('focus-3th-result').value,
+      document.getElementById('focus-4th-result').value,
+      document.getElementById('focus-5th-result').value,
+      document.getElementById('focus-6th-result').value,
+      document.getElementById('focus-7th-result').value,
+      document.getElementById('focus-8th-result').value,
+      document.getElementById('focus-9th-result').value,
+    ],
+    navigatePreviousResultPage: document.getElementById('navigate-previous-result-page').value,
+    navigateNextResultPage: document.getElementById('navigate-next-result-page').value,
     navigateKey: document.getElementById('navigate-key').value,
     navigateNewTabKey: document.getElementById('navigate-new-tab-key').value,
     navigateNewTabBackgroundKey: document.getElementById(
@@ -66,6 +75,16 @@ const restoreOptions = () => {
       values.autoSelectFirst;
     document.getElementById('next-key').value = values.nextKey;
     document.getElementById('previous-key').value = values.previousKey;
+    document.getElementById('focus-0th-result').value = values.focusSpecificResult[0];
+    document.getElementById('focus-1th-result').value = values.focusSpecificResult[1];
+    document.getElementById('focus-2th-result').value = values.focusSpecificResult[2];
+    document.getElementById('focus-3th-result').value = values.focusSpecificResult[3];
+    document.getElementById('focus-4th-result').value = values.focusSpecificResult[4];
+    document.getElementById('focus-5th-result').value = values.focusSpecificResult[5];
+    document.getElementById('focus-6th-result').value = values.focusSpecificResult[6];
+    document.getElementById('focus-7th-result').value = values.focusSpecificResult[7];
+    document.getElementById('focus-8th-result').value = values.focusSpecificResult[8];
+    document.getElementById('focus-9th-result').value = values.focusSpecificResult[9];
     document.getElementById('navigate-previous-result-page').value =
       values.navigatePreviousResultPage;
     document.getElementById('navigate-next-result-page').value =


### PR DESCRIPTION
As discussed in #70 , this adds keybindings to focus results 1-10 on page. **By default, they are set to keys `1` - `0`**.

I don't know if it would actually bother anyone, but adding 10 new options can make them look kind of cluttered.