### PR TITLE
Extend results selector to catch twitter links

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -325,7 +325,7 @@ const getGoogleSearchLinks = () => {
   return new SearchResultCollection(
     [
       [
-        document.querySelectorAll('#search .r > a:first-of-type'),
+        document.querySelectorAll('#search .r > a:first-of-type, #search .r g-link > a:first-of-type'),
         n => n.parentElement.parentElement
       ],
       [document.querySelectorAll('div.zjbNbe > a'), null],


### PR DESCRIPTION
A simple change in the css selector for search result nodes. Some links to twitter were being ignored by the current selector, for example:

![twitterlinks](https://user-images.githubusercontent.com/4010711/53919479-85e56a00-4040-11e9-865a-11cadf1c92fa.png)

These aren't necessarily card-like results:

![twitterlinks2](https://user-images.githubusercontent.com/4010711/53919823-85010800-4041-11e9-9b73-6603b4ad57bc.png)
