### PR TITLE
Navigate using the "o" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _Note: All shortcuts can be customized to your liking via options._
 *   `↓`/`j`: Select next search result
 *   `↑`/`k`: Select previous previous result
 *   `/`/`Escape`: Focus on input search box
-*   `Enter`/`Space`: Navigate to selected result
+*   `Enter`/`Space`/`o`: Navigate to selected result
 *   `Ctrl+Enter`/`⌘+Enter`/`Ctrl+Space`: Open selected result in background tab
 *   `Ctrl+Shift+Enter`/`⌘+Shift+Enter`/`Ctrl+Shift+Space`: Open selected result in new window/tab
 *   `←`/`h`: Navigate to previous search result page

--- a/src/extension.js
+++ b/src/extension.js
@@ -11,7 +11,7 @@ const extension = {
       previousKey: ['up', 'k'],
       navigatePreviousResultPage: ['left', 'h'],
       navigateNextResultPage: ['right', 'l'],
-      navigateKey: ['return', 'space'],
+      navigateKey: ['return', 'space', 'o'],
       navigateNewTabBackgroundKey: ['ctrl+return', 'command+return', 'ctrl+space'],
       navigateNewTabKey: ['ctrl+shift+return', 'command+shift+return', 'ctrl+shift+space'],
       navigateSearchTab: ['a', 's'],

--- a/src/options.html
+++ b/src/options.html
@@ -56,7 +56,7 @@
         </div>
         <div class="option">
             <label for="navigate-key" class="option-desc">Open</label>
-            <input id="navigate-key" class="input-keybinding" type="text" value="return, space">
+            <input id="navigate-key" class="input-keybinding" type="text" value="return, space, o">
         </div>
         <div class="option">
             <label for="navigate-new-tab-background-key" class="option-desc">Open in a new background tab</label>


### PR DESCRIPTION
Many websites that support `j` and `k` navigation uses `o` to open the selected item. Try github repos and gmail for instance.

I did not add `ctrl+o` and `ctrl+shift+o` (and mac equivalent) because they already have a different meaning in browsers. 