### PR TITLE
Multiple search engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .DS_Store
 src/mousetrap.js
 src/mousetrap-global-bind.js
+.eslintrc.js

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 src/mousetrap.js
 src/mousetrap-global-bind.js
 .eslintrc.js
+.vscode/

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,7 +4,7 @@ const browser = this.chrome && chrome.runtime ? chrome : this.browser;
 const extension = {
   options: {
     sync: new OptionSection(browser.storage.sync, {
-      delay: 900,
+      delay: 0,
       wrapNavigation: false,
       hideOutline: false,
       autoSelectFirst: true,

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,6 +4,7 @@ const browser = this.chrome && chrome.runtime ? chrome : this.browser;
 const extension = {
   options: {
     sync: new OptionSection(browser.storage.sync, {
+      delay: 900,
       wrapNavigation: false,
       hideOutline: false,
       autoSelectFirst: true,

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,7 +31,10 @@ const extension = {
       navigateShowWeek: ['z w', 'ctrl+shift+w', 'command+shift+w'],
       navigateShowMonth: ['z m', 'ctrl+shift+m', 'command+shift+m'],
       navigateShowYear: ['z y', 'ctrl+shift+y', 'command+shift+y'],
-      toggleSort: ['z s', 'ctrl+shift+s', 'command+shift+s']
+      toggleSort: ['z s', 'ctrl+shift+s', 'command+shift+s'],
+      searchEngines: {
+        startpage: false,
+      },
     }),
 
     local: new OptionSection(browser.storage.local, {
@@ -43,6 +46,13 @@ const extension = {
       return Promise.all([this.local.load(), this.sync.load()]);
     }
   }
+};
+
+// Authorized urls for compatible search engines
+const searchEnginesUrls = {
+  startpage: [
+    'https://www.startpage.com/*/*search*',
+  ],
 };
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,9 @@ Object.assign(extension, {
   searchEngine: getSearchEngine(),
 
   init(loadOptions) {
-    this.searchEngine.init(loadOptions);
+    if (this.searchEngine.init()) {
+      loadOptions.then(() => this.initResultsNavigation());
+    }
     loadOptions.then(() => this.initCommonSearchNavigation());
   },
   /**
@@ -242,7 +244,7 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
     // the search result link.
     if (scrollToResult) {
       const container = newItem.getContainer() || newItem.anchor;
-      scrollToElement(container, extension.searchEngine.marginTop, extension.searchEngine.marginBottom);
+      scrollToElement(container);
     }
     this.focusedIndex = index;
   };
@@ -264,10 +266,10 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
   };
 }
 
-const scrollToElement = (element, marginTop, marginBottom) => {
+const scrollToElement = (element) => {
   // Only use margins if they exists
-  marginTop = marginTop || 0;
-  marginBottom = marginBottom || 0;
+  const marginTop = extension.searchEngine.marginTop || 0;
+  const marginBottom = extension.searchEngine.marginBottom || 0;
   const elementBounds = element.getBoundingClientRect();
   // Firefox displays tooltip at the bottom which obstructs the view
   // as a workaround ensure extra space from the bottom in the viewport

--- a/src/main.js
+++ b/src/main.js
@@ -242,7 +242,7 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
     // the search result link.
     if (scrollToResult) {
       const container = newItem.getContainer() || newItem.anchor;
-      scrollToElement(container);
+      scrollToElement(container, extension.searchEngine.marginTop, extension.searchEngine.marginBottom);
     }
     this.focusedIndex = index;
   };
@@ -264,7 +264,10 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
   };
 }
 
-const scrollToElement = element => {
+const scrollToElement = (element, marginTop, marginBottom) => {
+  // Only use margins if they exists
+  marginTop = marginTop || 0;
+  marginBottom = marginBottom || 0;
   const elementBounds = element.getBoundingClientRect();
   // Firefox displays tooltip at the bottom which obstructs the view
   // as a workaround ensure extra space from the bottom in the viewport
@@ -272,10 +275,11 @@ const scrollToElement = element => {
   const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
   // hardcoded height of the tooltip plus some margin
   const firefoxBottomDelta = 26;
-  const bottomDelta = isFirefox ? firefoxBottomDelta : 0;
-  if (elementBounds.top < 0) {
+  const bottomDelta = (isFirefox ? firefoxBottomDelta : 0) + marginBottom;
+  if (elementBounds.top < 0 + marginTop) {
     // scroll element to top
     element.scrollIntoView(true);
+    window.scrollBy(0, -marginTop);
   } else if (elementBounds.bottom + bottomDelta > window.innerHeight) {
     // scroll element to bottom
     element.scrollIntoView(false);

--- a/src/main.js
+++ b/src/main.js
@@ -20,17 +20,17 @@ Object.assign(extension, {
    * @return {Element}
    */
   getElementToActivate(results, linkOnly = false) {
-    const focusedElement = document.activeElement;
+        const focusedElement = document.activeElement;
 
-    if (focusedElement !== null) {
-      const isLink = (focusedElement.localName === 'a' && focusedElement.hasAttribute('href'));
+        if (focusedElement !== null) {
+          const isLink = (focusedElement.localName === 'a' && focusedElement.hasAttribute('href'));
 
-      if (!linkOnly || isLink) {
-        return focusedElement;
-      }
-    }
+          if (!linkOnly || isLink) {
+            return focusedElement;
+          }
+        }
 
-    return results.items[results.focusedIndex].anchor;
+        return results.items[results.focusedIndex].anchor;
   },
 
   initResultsNavigation(searchEngine) {
@@ -210,21 +210,29 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
     }
   });
   this.focusedIndex = 0;
+  this.getHighlightedElement = function (index) {
+    if (extension.searchEngine.HighlightedParentSelector !== undefined) {
+        return this.items[index].anchor.closest(extension.searchEngine.HighlightedParentSelector)
+    } else {
+        return this.items[index].anchor
+    }
+  }
   this.focus = function (index, scrollToResult = true) {
     if (this.focusedIndex >= 0) {
-      let item = this.items[this.focusedIndex];
+      let item = this.getHighlightedElement(this.focusedIndex);
       // Remove focus outline from previous item.
-      item && item.anchor.classList.remove('focused-search-result');
-      item && item.anchor.classList.remove('no-outline');
+      item.classList.remove(extension.searchEngine.HighlightClass);
+      item.classList.remove('no-outline');
     }
-    const newItem = this.items[index];
+    const Highlighted = this.getHighlightedElement(index);
+    const newItem = this.items[index]
     // Exit if no new item.
     if (!newItem) {
       this.focusedIndex = -1;
       return;
     }
     // Add the focus outline and caret.
-    newItem.anchor.classList.add('focused-search-result');
+    Highlighted.classList.add(extension.searchEngine.HighlightClass);
     // Hide focus outline if requested in options.
     if (extension.options.sync.values.hideOutline) {
       newItem.anchor.classList.add('no-outline');

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ Object.assign(extension, {
       // DOMContentLoaded.
       loadOptions.then(() => this.initResultsNavigation(this.searchEngine));
     }
-    loadOptions.then(() => this.initCommonGoogleSearchNavigation(this.searchEngine.tabs));
+    loadOptions.then(() => this.initCommonSearchNavigation(this.searchEngine.tabs));
   },
   /**
    * Gets the element to activate upon navigation. The focused element in the document is preferred (if there is one)
@@ -100,7 +100,7 @@ Object.assign(extension, {
     this.register(options.toggleSort, () => searchEngine.changeTools(null));
   },
 
-  initCommonGoogleSearchNavigation(tabs) {
+  initCommonSearchNavigation(tabs) {
     const options = this.options.sync.values;
 
     // Bind globally otherwise Mousetrap ignores keypresses inside inputs.
@@ -224,7 +224,7 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
       item.classList.remove(extension.searchEngine.HighlightClass);
       item.classList.remove('no-outline');
     }
-    const Highlighted = this.getHighlightedElement(index);
+    const highlighted = this.getHighlightedElement(index);
     const newItem = this.items[index]
     // Exit if no new item.
     if (!newItem) {
@@ -232,7 +232,7 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
       return;
     }
     // Add the focus outline and caret.
-    Highlighted.classList.add(extension.searchEngine.HighlightClass);
+    highlighted.classList.add(extension.searchEngine.HighlightClass);
     // Hide focus outline if requested in options.
     if (extension.options.sync.values.hideOutline) {
       newItem.anchor.classList.add('no-outline');

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,8 @@
 Object.assign(extension, {
   searchEngine: getSearchEngine(),
 
-   init(loadOptions) {
-    // Don't initialize results navigation on image search, since it doesn't work
-    // there.
-    if (!/[?&]tbm=isch(&|$)/.test(location.search)) {
-      // This file is loaded only after the DOM is ready, so no need to wait for
-      // DOMContentLoaded.
-      loadOptions.then(() => this.initResultsNavigation());
-    }
+  init(loadOptions) {
+    this.searchEngine.init(loadOptions);
     loadOptions.then(() => this.initCommonSearchNavigation());
   },
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,9 @@ Object.assign(extension, {
     if (!/[?&]tbm=isch(&|$)/.test(location.search)) {
       // This file is loaded only after the DOM is ready, so no need to wait for
       // DOMContentLoaded.
-      loadOptions.then(() => this.initResultsNavigation(this.searchEngine));
+      loadOptions.then(() => this.initResultsNavigation());
     }
-    loadOptions.then(() => this.initCommonSearchNavigation(this.searchEngine.tabs));
+    loadOptions.then(() => this.initCommonSearchNavigation());
   },
   /**
    * Gets the element to activate upon navigation. The focused element in the document is preferred (if there is one)
@@ -33,10 +33,10 @@ Object.assign(extension, {
         return results.items[results.focusedIndex].anchor;
   },
 
-  initResultsNavigation(searchEngine) {
+  initResultsNavigation() {
     const options = this.options.sync.values;
     const lastNavigation = this.options.local.values;
-    const results = searchEngine.getSearchLinks();
+    const results = this.searchEngine.getSearchLinks();
 
     let isFirstNavigation = true;
     if (options.autoSelectFirst) {
@@ -91,16 +91,17 @@ Object.assign(extension, {
         }
       });
     });
-    this.register(options.navigateShowAll, () => searchEngine.changeTools('a'));
-    this.register(options.navigateShowHour, () => searchEngine.changeTools('h'));
-    this.register(options.navigateShowDay, () => searchEngine.changeTools('d'));
-    this.register(options.navigateShowWeek, () => searchEngine.changeTools('w'));
-    this.register(options.navigateShowMonth, () => searchEngine.changeTools('m'));
-    this.register(options.navigateShowYear, () => searchEngine.changeTools('y'));
-    this.register(options.toggleSort, () => searchEngine.changeTools(null));
+    this.register(options.navigateShowAll, () => this.searchEngine.changeTools('a'));
+    this.register(options.navigateShowHour, () => this.searchEngine.changeTools('h'));
+    this.register(options.navigateShowDay, () => this.searchEngine.changeTools('d'));
+    this.register(options.navigateShowWeek, () => this.searchEngine.changeTools('w'));
+    this.register(options.navigateShowMonth, () => this.searchEngine.changeTools('m'));
+    this.register(options.navigateShowYear, () => this.searchEngine.changeTools('y'));
+    this.register(options.toggleSort, () => this.searchEngine.changeTools(null));
   },
 
-  initCommonSearchNavigation(tabs) {
+  initCommonSearchNavigation() {
+    const tabs = this.searchEngine.tabs;
     const options = this.options.sync.values;
 
     // Bind globally otherwise Mousetrap ignores keypresses inside inputs.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,13 +16,20 @@
         }
     },
     "permissions": ["storage"],
+    "optional_permissions": [
+        "http://*/*",
+        "https://*/*"
+    ],
     "options_page": "options.html",
     "options_ui": {
         "page": "options.html",
         "chrome_style": true
     },
     "background": {
-        "scripts": ["background.js"],
+        "scripts": [
+            "webext-dynamic-content-scripts.js",
+            "background.js"
+        ],
         "persistent": false
     },
     "content_scripts": [
@@ -39,8 +46,6 @@
             ],
             "run_at": "document_end",
             "matches": [
-                "*://www.startpage.com/sp/search*",
-                "*://www.startpage.com/do/dsearch*",
                 "*://www.google.com/search*",
                 "*://www.google.ad/search*",
                 "*://www.google.ae/search*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,6 +31,7 @@
                 "mousetrap.js",
                 "mousetrap-global-bind.js",
                 "extension.js",
+                "searchEngines.js",
                 "main.js"
             ],
             "css": [
@@ -38,6 +39,8 @@
             ],
             "run_at": "document_end",
             "matches": [
+                "*://www.startpage.com/sp/search*",
+                "*://www.startpage.com/do/dsearch*",
                 "*://www.google.com/search*",
                 "*://www.google.ad/search*",
                 "*://www.google.ae/search*",

--- a/src/options.html
+++ b/src/options.html
@@ -27,6 +27,12 @@
             <input type="number" id="delay"> Delay extension initialization
         </label>
     </div>
+    <div id="searchEngines-container">
+        <h3>Search engines</h3>
+        <div class="option">
+            <input type="checkbox" id="startpage" name="startpage">Add startpage</input>
+        </div>
+    </div>
     <div id="keybindings-container">
         <h3>Keybindings</h3>
         <div id="keybindings-help">

--- a/src/options.html
+++ b/src/options.html
@@ -22,6 +22,11 @@
             <input type="checkbox" id="hide-outline"> Hide outline on selected search result
         </label>
     </div>
+    <div class="option">
+        <label for="delay">
+            <input type="number" id="delay"> Delay extension initialization
+        </label>
+    </div>
     <div id="keybindings-container">
         <h3>Keybindings</h3>
         <div id="keybindings-help">

--- a/src/options.js
+++ b/src/options.js
@@ -36,6 +36,8 @@ const divToOptionName = {
   toggleSort: 'toggle-sort'
 };
 
+const startpage = document.getElementById('startpage');
+
 // Saves options to chrome.storage.sync.
 const saveOptions = () => {
 
@@ -44,6 +46,7 @@ const saveOptions = () => {
   extension.options.sync.values.autoSelectFirst = document.getElementById('auto-select-first').checked
   extension.options.sync.values.hideOutline = document.getElementById('hide-outline').checked
   extension.options.sync.values.delay = document.getElementById('delay').value
+  extension.options.sync.values.searchEngines.startpage = startpage.checked;
 
   // Save options from divs.
   for(let key in divToOptionName) {
@@ -71,6 +74,7 @@ const restoreOptions = () => {
     document.getElementById('auto-select-first').checked = extension.options.sync.values.autoSelectFirst;
     document.getElementById('hide-outline').checked = extension.options.sync.values.hideOutline;
     document.getElementById('delay').value = extension.options.sync.values.delay;
+    startpage.checked = extension.options.sync.values.searchEngines.startpage;
 
     // Restore options from divs.
     for(let key in divToOptionName) {
@@ -85,3 +89,23 @@ const restoreOptions = () => {
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.getElementById('save').addEventListener('click', saveOptions);
+
+startpage.addEventListener('change', () => {
+  addSearchEnginePermission(startpage);
+});
+
+/**
+ * Add other search engines domain on user input
+ * @param {Element} checkbox
+ */
+const addSearchEnginePermission = (checkbox) => {
+  if (checkbox.checked) {
+    browser.permissions.request({
+      origins: searchEnginesUrls[checkbox.name],
+    });
+  } else {
+    browser.permissions.remove({
+      origins: searchEnginesUrls[checkbox.name],
+    });
+  }
+};

--- a/src/options.js
+++ b/src/options.js
@@ -43,8 +43,9 @@ const saveOptions = () => {
   extension.options.sync.values.wrapNavigation = document.getElementById('wrap-navigation').checked
   extension.options.sync.values.autoSelectFirst = document.getElementById('auto-select-first').checked
   extension.options.sync.values.hideOutline = document.getElementById('hide-outline').checked
+  extension.options.sync.values.delay = document.getElementById('delay').value
 
-  // Save options from divs. 
+  // Save options from divs.
   for(let key in divToOptionName) {
 
     // Options take commands as strings separated by commas.
@@ -69,8 +70,9 @@ const restoreOptions = () => {
     document.getElementById('wrap-navigation').checked = extension.options.sync.values.wrapNavigation;
     document.getElementById('auto-select-first').checked = extension.options.sync.values.autoSelectFirst;
     document.getElementById('hide-outline').checked = extension.options.sync.values.hideOutline;
+    document.getElementById('delay').value = extension.options.sync.values.delay;
 
-    // Restore options from divs. 
+    // Restore options from divs.
     for(let key in divToOptionName) {
 
       // Options are stored as arrays.

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -5,6 +5,7 @@ const options = extension.options.sync.values;
  *
  * A search engine object has to provide the following :
  *
+ *  - {boolean} canInit()
  *  - {regex} urlPattern
  *  - {CSS selector} searchBoxSelector
  *  - {SearchResultCollection} getSearchLinks()
@@ -21,7 +22,7 @@ const options = extension.options.sync.values;
 const searchEngines = [
     // Google
     {
-        init() {
+        canInit() {
             // Don't initialize results navigation on image search, since it doesn't work
             // there.
             return !this.contexts.images()
@@ -102,7 +103,7 @@ const searchEngines = [
 
     // Startpage
     {
-        init() {
+        canInit() {
             // Don't initialize results navigation on image search, since it doesn't work
             // there.
             return !this.contexts.images();
@@ -126,8 +127,8 @@ const searchEngines = [
         HighlightClass: 'startpage-focused-search-result',
         // The HighlightClass style will be applied on the closest parent of the focused element matching this selector
         // When not set, HighlightClass style is applied on the focused element itself
-        HighlightedParentSelector: '.w-gl__result',
-        marginTop: getFromContext('search', 113, 0),
+        HighlightedParentSelector: ['.w-gl__result', ['search'], null],
+        marginTop: [113, ['search'], 0],
         getSearchLinks () {
             return new SearchResultCollection(
                 [
@@ -188,15 +189,4 @@ function getSearchEngine() {
         }
     }
     return null;
-}
-
-/**
- * Return value if context is valid
- * @param {boolean} context, the returned value on valid context *
- * @param {*} value, the returned value on valid context
- * @param {*} defaultValue, the returned value on invalid context
- * @return {*} either value or defaultValue depending on context
- */
-function getFromContext(context, value, defaultValue) {
-  return (context ? value : defaultValue);
 }

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -9,6 +9,10 @@ const options = extension.options.sync.values;
  *  - {CSS selector} searchBoxSelector
  *  - {SearchResultCollection} getSearchLinks()
  *  - {None} changeTools(period)
+ *  - {CSS class name} HighlightClass
+ *
+ * Optionnal :
+ *  - {CSS selector} HighlightedParentSelector
  */
 const searchEngines = [
     // Google
@@ -17,6 +21,7 @@ const searchEngines = [
         urlPattern: /^(www|encrypted)\.google\./,
         // Must match search engine search box
         searchBoxSelector: '#searchform input[name=q]',
+        HighlightClass: 'default-focused-search-result',
         /**
          * Array storing tuples of tabs name and their corresponding CSS selector
          */
@@ -85,13 +90,18 @@ const searchEngines = [
     {
         urlPattern: /^(www|encrypted)\.startpage\./,
         searchBoxSelector: '.search-form__form input[id=q]',
+        HighlightClass: 'startpage-focused-search-result',
+        // The HighlightClass style will be applied on the closest parent of the focused element matching this selector
+        // When not set, HighlightClass style is applied on the focused element itself
+        HighlightedParentSelector: '.w-gl__result',
+
         getSearchLinks () {
             return new SearchResultCollection(
                 [
                   [
-                    document.querySelectorAll('.w-gl--default.w-gl .w-gl__result > a.w-gl__result-url'),
-                    n => n.parentElement.parentElement
-                  ]
+                    document.querySelectorAll('.w-gl--default.w-gl .w-gl__result > .w-gl__result-title'),
+                    n => n.parentElement.parentElement,
+                  ],
                 ]
               );
         },

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -24,7 +24,7 @@ const searchEngines = [
             if (!/[?&]tbm=isch(&|$)/.test(location.search)) {
                 // This file is loaded only after the DOM is ready, so no need to wait for
                 // DOMContentLoaded.
-                loadOptions.then(() => this.initResultsNavigation());
+                loadOptions.then(() => extension.initResultsNavigation());
             }
         },
         // Must match search engine url

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -88,7 +88,7 @@ const searchEngines = [
 
     // Startpage
     {
-        urlPattern: /^(www|encrypted)\.startpage\./,
+        urlPattern: /^www\.startpage\./,
         searchBoxSelector: '.search-form__form input[id=q]',
         HighlightClass: 'startpage-focused-search-result',
         // The HighlightClass style will be applied on the closest parent of the focused element matching this selector

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -176,4 +176,5 @@ function getSearchEngine() {
             return searchEngines[i]
         }
     }
+    return null;
 }

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -14,9 +14,19 @@ const options = extension.options.sync.values;
  * Optionnal :
  *  - {CSS selector} HighlightedParentSelector
  */
+
 const searchEngines = [
     // Google
     {
+        init(loadOptions) {
+            // Don't initialize results navigation on image search, since it doesn't work
+            // there.
+            if (!/[?&]tbm=isch(&|$)/.test(location.search)) {
+                // This file is loaded only after the DOM is ready, so no need to wait for
+                // DOMContentLoaded.
+                loadOptions.then(() => this.initResultsNavigation());
+            }
+        },
         // Must match search engine url
         urlPattern: /^(www|encrypted)\.google\./,
         // Must match search engine search box
@@ -88,6 +98,15 @@ const searchEngines = [
 
     // Startpage
     {
+        init(loadOptions) {
+            // Don't initialize results navigation on image search, since it doesn't work
+            // there.
+            if (!document.querySelector('div.layout-images')) {
+                // This file is loaded only after the DOM is ready, so no need to wait for
+                // DOMContentLoaded.
+                loadOptions.then(() => extension.initResultsNavigation());
+            }
+        },
         urlPattern: /^www\.startpage\./,
         searchBoxSelector: '.search-form__form input[id=q]',
         HighlightClass: 'startpage-focused-search-result',

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -1,0 +1,147 @@
+const options = extension.options.sync.values;
+
+/**
+ * Store all compatible saerch engines
+ *
+ * A search engine object has to provide the following :
+ *
+ *  - {regex} urlPattern
+ *  - {CSS selector} searchBoxSelector
+ *  - {SearchResultCollection} getSearchLinks()
+ *  - {None} changeTools(period)
+ */
+const searchEngines = [
+    // Google
+    {
+        // Must match search engine url
+        urlPattern: /^(www|encrypted)\.google\./,
+        // Must match search engine search box
+        searchBoxSelector: '#searchform input[name=q]',
+        /**
+         * Array storing tuples of tabs name and their corresponding CSS selector
+         */
+        tabs: [
+            [
+                options.navigateSearchTab,
+                'a.q.qs:not([href*="&tbm="]):not([href*="maps.google."])'
+            ],
+            [options.navigateImagesTab, 'a.q.qs[href*="&tbm=isch"]'],
+            [options.navigateVideosTab, 'a.q.qs[href*="&tbm=vid"]'],
+            [options.navigateMapsTab, 'a.q.qs[href*="maps.google."]'],
+            [options.navigateNewsTab, 'a.q.qs[href*="&tbm=nws"]'],
+            [options.navigateShoppingTab, 'a.q.qs[href*="&tbm=shop"]'],
+            [options.navigateBooksTab, 'a.q.qs[href*="&tbm=bks"]'],
+            [options.navigateFlightsTab, 'a.q.qs[href*="&tbm=flm"]'],
+            [options.navigateFinancialTab, 'a.q.qs[href*="&tbm=fin"]'],
+            [options.navigatePreviousResultPage, '#pnprev'],
+            [options.navigateNextResultPage, '#pnnext']
+        ],
+        /**
+         * Get result links
+         * @returns a SearchResultCollection object
+         */
+        getSearchLinks () {
+            return new SearchResultCollection(
+                [
+                    [
+                    document.querySelectorAll('#search .r > a:first-of-type, #search .r g-link > a:first-of-type'),
+                    n => n.parentElement.parentElement
+                    ],
+                    [document.querySelectorAll('div.zjbNbe > a'), null],
+                    [document.querySelectorAll('div.eIuuYe a'), null], // shopping results
+                    [document.querySelectorAll('#pnprev, #pnnext'), null]
+                ],
+                [document.querySelectorAll('#search .kp-blk .r > a:first-of-type')]
+                );
+        },
+        /**
+         *  Filter the results based on date
+         * @param {*} period, filter identifier. Accpeted filter are :
+         *  'h' : get results from last hour
+         *  'd' : get result from last day
+         *  'w' : get results from last week
+         *  'm' : get result from last month
+         *  'y' : get result from last year
+         */
+        changeTools(period) {
+            // Save current period and sort.
+            const res = /&(tbs=qdr:.)(,sbd:.)?/.exec(location.href);
+            const currPeriod = (res && res[1]) || '';
+            const currSort = (res && res[2]) || '';
+            // Remove old period and sort.
+            const strippedHref = location.href.replace(/&tbs=qdr:.(,sbd:.)?/, '');
+            if (period) {
+                location.href =
+                strippedHref + (period === 'a' ? '' : '&tbs=qdr:' + period + currSort);
+            } else if (currPeriod) {
+                // Can't apply sort when not using period.
+                location.href =
+                strippedHref + '&' + currPeriod + (currSort ? '' : ',sbd:1');
+            }
+        }
+    },
+
+    // Startpage
+    {
+        urlPattern: /^(www|encrypted)\.startpage\./,
+        searchBoxSelector: '.search-form__form input[id=q]',
+        getSearchLinks () {
+            return new SearchResultCollection(
+                [
+                  [
+                    document.querySelectorAll('.w-gl--default.w-gl .w-gl__result > a.w-gl__result-url'),
+                    n => n.parentElement.parentElement
+                  ]
+                ]
+              );
+        },
+        tabs: [
+            [options.navigateSearchTab, 'div.inline-nav-menu__container > form.inline[action="/sp/search"]:first-of-type'],
+            [options.navigateImagesTab, 'div.inline-nav-menu__container > form.inline[action="/sp/search"]:nth-of-type(2)'],
+            [options.navigateVideosTab, 'div.inline-nav-menu__container > form.inline[action="/sp/search"]:last-of-type'],
+            [options.navigatePreviousResultPage, 'form.pagination__form.next-prev-form--desktop:first-of-type'],
+            [options.navigateNextResultPage, 'form.pagination__form.next-prev-form--desktop:last-of-type']
+          ],
+        changeTools(period) {
+            const forms = document.forms
+            let timeForm
+
+            for (let i = 0; i < forms.length; i++) {
+                if (forms[i].className === "search-filter-time__form") {
+                    timeForm = forms[i]
+                }
+            }
+
+            switch (period) {
+                case 'd':
+                    timeForm.elements["with_date"][1].click()
+                    break;
+                case 'w':
+                    timeForm.elements["with_date"][2].click()
+                    break;
+                case 'm':
+                    timeForm.elements["with_date"][3].click()
+                    break;
+                case 'y':
+                    timeForm.elements["with_date"][4].click()
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+]
+
+/**
+ * Get search engine object matching the current url
+ * @returns search engine
+ */
+function getSearchEngine() {
+    // Switch over all compatible search engines
+    const host = window.location.hostname
+    for (let i = 0; i < searchEngines.length; i++) {
+        if (host.match(searchEngines[i].urlPattern)) {
+            return searchEngines[i]
+        }
+    }
+}

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -11,9 +11,36 @@ const options = extension.options.sync.values;
  *  - {SearchResultCollection} getSearchLinks()
  *  - {None} changeTools(period)
  *  - {CSS class name} HighlightClass
+ *  - {Array} tabs
  *
- * Optionnal :
+ * Contexts :
+ *
+ * Some properties can be setted on specified context.
+ * For this, you need a contexts object inside your search engine object.
+ * As the name suggest, it hold contexts, that are function returning
+ * a boulean if a specified context is matched.
+ * For example, a context can be the presence of a special element in the
+ * page, indicating that you are on a page where you need the property.
+ *
+ * A context-able property must follow this structure :
+ *
+ * property: [value, [contextA, contextB], defaultValue]
+ *
+ * property will be setted to value when contextA or contextB will be true.
+ * If all contexts are false, it will be setted to defaultValue
+ *
+ * Note that context-able properties MUST have a context array containing
+ * at least one context. If you want to set the same value for all context
+ * You can use 'all' keyword :
+ *
+ * property: [value, ['all']]
+ *
+ * Context-able properties :
+ *
  *  - {CSS selector} HighlightedParentSelector
+ *      When setted, the closest parent element of the focused one matching this
+ *      Selector will be highlighted
+ *
  *  - {number} marginTop, Set this if top results are not entirely visisble
  *  - {number} marginBottom, Set this if bottom results are not entirely visisble
  *
@@ -22,6 +49,10 @@ const options = extension.options.sync.values;
 const searchEngines = [
     // Google
     {
+        /**
+         * @returns {boolean} true if result navigation keybindings can be,
+         *  initialized or false if only global keybindings can be initialized
+         */
         canInit() {
             // Don't initialize results navigation on image search, since it doesn't work
             // there.
@@ -136,6 +167,7 @@ const searchEngines = [
                     document.querySelectorAll('.w-gl--default.w-gl .w-gl__result > .w-gl__result-title'),
                     n => n.parentElement,
                   ],
+                  [document.querySelectorAll('.vo-sp.vo-sp--default > a.vo-sp__link'), null],
                 ]
               );
         },

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -13,6 +13,9 @@ const options = extension.options.sync.values;
  *
  * Optionnal :
  *  - {CSS selector} HighlightedParentSelector
+ *  - {number} marginTop, Set this if top results are not entirely visisble
+ *  - {number} marginBottom, Set this if bottom results are not entirely visisble
+ *
  */
 
 const searchEngines = [
@@ -113,13 +116,13 @@ const searchEngines = [
         // The HighlightClass style will be applied on the closest parent of the focused element matching this selector
         // When not set, HighlightClass style is applied on the focused element itself
         HighlightedParentSelector: '.w-gl__result',
-
+        marginTop: document.querySelector('body > div.layout.layout--default > div.layout__header > div > div').offsetHeight,
         getSearchLinks () {
             return new SearchResultCollection(
                 [
                   [
                     document.querySelectorAll('.w-gl--default.w-gl .w-gl__result > .w-gl__result-title'),
-                    n => n.parentElement.parentElement,
+                    n => n.parentElement,
                   ],
                 ]
               );

--- a/src/search_results.css
+++ b/src/search_results.css
@@ -1,8 +1,15 @@
-.focused-search-result::before {
+.default-focused-search-result::before {
   content: "\25BA";
   margin-right: 25px;
   left: -25px;
   position: absolute;
+}
+
+.startpage-focused-search-result {
+    border-color: #4caf50!important;
+    border-width: 2px;
+    border-style: double;
+    border-radius: 9px;
 }
 
 .no-outline,

--- a/src/webext-dynamic-content-scripts.js
+++ b/src/webext-dynamic-content-scripts.js
@@ -1,0 +1,241 @@
+/* https://github.com/fregante/webext-dynamic-content-scripts @ v6.0.3 */
+
+(function() {
+  'use strict';
+
+  function urlGlobToRegex(matchPattern) {
+    return (
+      '^' +
+      matchPattern
+          .replace(/[.]/g, '\\.')
+          .replace(/[?]/, '.')
+          .replace(/^[*]:/, 'https?')
+          .replace(/^(https[?]?:[/][/])[*]/, '$1[^/:]+')
+          .replace(/[/][*]/, '/?.+')
+          .replace(/[*]/g, '.+')
+          .replace(/[/]/g, '\\/')
+    );
+  }
+  async function p(fn, ...args) {
+    return new Promise((resolve, reject) => {
+      fn(...args, (result) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+  async function isOriginPermitted(url) {
+    return p(chrome.permissions.contains, {
+      origins: [new URL(url).origin + '/*'],
+    });
+  }
+  async function wasPreviouslyLoaded(tabId, loadCheck) {
+    const result = await p(chrome.tabs.executeScript, tabId, {
+      code: loadCheck,
+      runAt: 'document_start',
+    });
+    return result && result[0];
+  }
+  if (!chrome.contentScripts) {
+    chrome.contentScripts = {
+      async register(contentScriptOptions, callback) {
+        const {
+          js = [],
+          css = [],
+          allFrames,
+          matchAboutBlank,
+          matches,
+          runAt,
+        } = contentScriptOptions;
+        const loadCheck = `document[${JSON.stringify(
+            JSON.stringify({js, css})
+        )}]`;
+        const matchesRegex = new RegExp(
+            matches.map(urlGlobToRegex).join('$') + '$'
+        );
+        const listener = async (tabId, {status}) => {
+          if (status !== 'loading') {
+            return;
+          }
+          const {url} = await p(chrome.tabs.get, tabId);
+          if (
+            !url ||
+            !matchesRegex.test(url) ||
+            !(await isOriginPermitted(url)) ||
+            (await wasPreviouslyLoaded(tabId, loadCheck))
+          ) {
+            return;
+          }
+          for (const file of css) {
+            chrome.tabs.insertCSS(tabId, {
+              ...file,
+              matchAboutBlank,
+              allFrames,
+              runAt: runAt || 'document_start',
+            });
+          }
+          for (const file of js) {
+            chrome.tabs.executeScript(tabId, {
+              ...file,
+              matchAboutBlank,
+              allFrames,
+              runAt,
+            });
+          }
+          chrome.tabs.executeScript(tabId, {
+            code: `${loadCheck} = true`,
+            runAt: 'document_start',
+            allFrames,
+          });
+        };
+        chrome.tabs.onUpdated.addListener(listener);
+        const registeredContentScript = {
+          async unregister() {
+            return p(
+                chrome.tabs.onUpdated.removeListener.bind(chrome.tabs.onUpdated),
+                listener
+            );
+          },
+        };
+        if (typeof callback === 'function') {
+          callback(registeredContentScript);
+        }
+        return Promise.resolve(registeredContentScript);
+      },
+    };
+  }
+
+  const events = [['request', 'onAdded'], ['remove', 'onRemoved']];
+  if (chrome.permissions && !chrome.permissions.onAdded) {
+    for (const [action, event] of events) {
+      const act = chrome.permissions[action];
+      const listeners = new Set();
+      chrome.permissions[event] = {
+        addListener(callback) {
+          listeners.add(callback);
+        },
+      };
+      chrome.permissions[action] = (permissions, callback) => {
+        const initial = browser.permissions.contains(permissions);
+        const expected = action === 'request';
+        act(permissions, async (successful) => {
+          if (callback) {
+            callback(successful);
+          }
+          if (!successful) {
+            return;
+          }
+          if ((await initial) !== expected) {
+            const fullPermissions = {
+              origins: [],
+              permissions: [],
+              ...permissions,
+            };
+            chrome.permissions.getAll(() => {
+              for (const listener of listeners) {
+                setTimeout(listener, 0, fullPermissions);
+              }
+            });
+          }
+        });
+      };
+      browser.permissions[event] = chrome.permissions[event];
+      browser.permissions[action] = async (permissions) =>
+        new Promise((resolve, reject) => {
+          chrome.permissions[action](permissions, (result) => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(result);
+            }
+          });
+        });
+    }
+  }
+
+  async function getManifestPermissions() {
+    const manifest = chrome.runtime.getManifest();
+    const manifestPermissions = {
+      origins: [],
+      permissions: [],
+    };
+    const list = new Set([
+      ...(manifest.permissions || []),
+      ...(manifest.content_scripts || []).flatMap(
+          (config) => config.matches || []
+      ),
+    ]);
+    for (const permission of list) {
+      if (permission.includes('://')) {
+        manifestPermissions.origins.push(permission);
+      } else {
+        manifestPermissions.permissions.push(permission);
+      }
+    }
+    return manifestPermissions;
+  }
+  async function getAdditionalPermissions() {
+    const manifestPermissions = await getManifestPermissions();
+    return new Promise((resolve) => {
+      chrome.permissions.getAll((currentPermissions) => {
+        const additionalPermissions = {
+          origins: [],
+          permissions: [],
+        };
+        for (const origin of currentPermissions.origins || []) {
+          if (!manifestPermissions.origins.includes(origin)) {
+            additionalPermissions.origins.push(origin);
+          }
+        }
+        for (const permission of currentPermissions.permissions || []) {
+          if (!manifestPermissions.permissions.includes(permission)) {
+            additionalPermissions.permissions.push(permission);
+          }
+        }
+        resolve(additionalPermissions);
+      });
+    });
+  }
+
+  const registeredScripts = new Map();
+  function convertPath(file) {
+    const url = new URL(file, location.origin);
+    return {file: url.pathname};
+  }
+  async function registerOnOrigins({origins: newOrigins}) {
+    const manifest = chrome.runtime.getManifest().content_scripts;
+    for (const origin of newOrigins || []) {
+      for (const config of manifest) {
+        const registeredScript = chrome.contentScripts.register({
+          js: (config.js || []).map(convertPath),
+          css: (config.css || []).map(convertPath),
+          allFrames: config.all_frames,
+          matches: [origin],
+          runAt: config.run_at,
+        });
+        registeredScripts.set(origin, registeredScript);
+      }
+    }
+  }
+  (async () => {
+    registerOnOrigins(await getAdditionalPermissions());
+  })();
+  chrome.permissions.onAdded.addListener((permissions) => {
+    if (permissions.origins && permissions.origins.length > 0) {
+      registerOnOrigins(permissions);
+    }
+  });
+  chrome.permissions.onRemoved.addListener(async ({origins}) => {
+    if (!origins || origins.length === 0) {
+      return;
+    }
+    for (const [origin, script] of registeredScripts) {
+      if (origins.includes(origin)) {
+        (await script).unregister();
+      }
+    }
+  });
+})();


### PR DESCRIPTION
I use startpage as my default search engine and i really miss this extension. So i've made some work allowing to quickly add any search engine compatibility, only by adding a `searchEngine object` in `src/searchEngine.js` (there would be no need to modify `src/main.js`).

**Changes** :
- search engine are now objects and lives in src/searchEngine.js and they are structured as follow :

    ```javascript
    const searchEngines [
        {
        urlPattern: regex,
        searchBoxSelector: CSS selector,
        HighlightClass: class name,
        tabs : [],
        getSearchLinks(),
        changeTools(period),
        [optionnal] HighlightedParentSelector: CSS selector
    },
    {
        ...
    }
    ]
    ```

- `urlPattern` is used in `getSearchEngine()`. It will iterate over all search engine objects and return the matching one. It's used by a property of `extension` object that hold the current search engine.

**New stuff** :

- I added an option to delay the initialization, as there is a tiny delay before results to be visible on startpage (after page is loaded), and first result isn't selected when auto select first is enabled.
I didn't hardcoded it because this delay depends on browser/conection. So this is here basically for compatibility purpose, it's not really a feature.
It's done by using an `async` wrapper function around `extension.init()`, and make this function sleeps with `await sleep()`. 

- There is the ability to highlight another element than the one focused (using `HighlightedParentSelector` property) so we have more choice when applying a custom style.

Here the highlighted element is the `div` containing the link, while the focused element is the link itself :
[![Image from Gyazo](https://i.gyazo.com/252dcb6a624156183f6ecbcd470cc67d.png)](https://gyazo.com/252dcb6a624156183f6ecbcd470cc67d)
Also, all search engine objects has to have a `highlightClass` property (but several search engine can use the same class) so each search engine can has its own highlight styling

**To do** :
- Make per-search-engine options

Now i can be produtive while keeping my data ;)