### PR TITLE
Specify parent tab for newely created tabs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,8 +4,7 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'tabsCreate') {
     browser.tabs.create({
       url: request.options.url,
-      active: request.options.active,
-      openerTabId: sender.tab.id
+      active: request.options.active
     });
   }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -4,7 +4,8 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.type === 'tabsCreate') {
     browser.tabs.create({
       url: request.options.url,
-      active: request.options.active
+      active: request.options.active,
+      openerTabId: sender.tab.id
     });
   }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -225,7 +225,8 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
     const highlighted = this.getHighlightedElement(index);
     const newItem = this.items[index]
     // Exit if no new item.
-    if (!newItem) {ex = -1;
+    if (!newItem) {
+      this.focusedIndex = -1;
       return;
     }
     // Add the focus outline and caret.

--- a/src/main.js
+++ b/src/main.js
@@ -225,8 +225,7 @@ function SearchResultCollection(includedNodeLists, excludedNodeLists) {
     const highlighted = this.getHighlightedElement(index);
     const newItem = this.items[index]
     // Exit if no new item.
-    if (!newItem) {
-      this.focusedIndex = -1;
+    if (!newItem) {ex = -1;
       return;
     }
     // Add the focus outline and caret.


### PR DESCRIPTION
Fixed #113. Now tabs created by background.js have an openerTabId property. 
The initial commit had a typo, which is the reason for the revert. 