### PR TITLE
Added Youtube support 

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -34,6 +34,7 @@ const extension = {
       toggleSort: ['z s', 'ctrl+shift+s', 'command+shift+s'],
       searchEngines: {
         startpage: false,
+        youtube: false
       },
     }),
 
@@ -53,6 +54,9 @@ const searchEnginesUrls = {
   startpage: [
     'https://www.startpage.com/*/*search*',
   ],
+  youtube: [
+    "*://www.youtube.com/*"
+  ]
 };
 
 /**

--- a/src/extension.js
+++ b/src/extension.js
@@ -55,7 +55,7 @@ const searchEnginesUrls = {
     'https://www.startpage.com/*/*search*',
   ],
   youtube: [
-    "*://www.youtube.com/*"
+    "https://www.youtube.com/*"
   ]
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,22 +4,8 @@ Object.assign(extension, {
   known_results: null,
   
   init(loadOptions) {
-    if(extension.searchEngine.name && extension.searchEngine.name == "Youtube"){
-      //Youtube uses infinite scrolling, so a Mutationobserver is needed
-      container = document.querySelector("div#contents div#contents");
-      const config = { attributes: false, childList: true, subtree: false };
-      let first_obversation = true;
-      const observer = new MutationObserver((mutationsList, observer) => {
-        if (first_obversation && this.known_results){
-          this.observedAdditions = this.known_results.items.length
-          first_obversation = false;
-        }
-        this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
-        if(this.known_results && this.known_results.items.length < this.observedAdditions){
-          loadOptions.then(() => this.initResultsNavigation());
-        }
-      })
-      observer.observe(container, config)
+    if(extension.searchEngine.endlessScrolling){
+      this.supportEndlessScrolling()
     }
     if (extension.searchEngine.canInit()) {
       loadOptions.then(() => this.initResultsNavigation());
@@ -182,6 +168,27 @@ Object.assign(extension, {
         return false;
       }
     });
+  },
+  supportEndlessScrolling(){
+    //The search engine uses endless scrolling, so a Mutationobserver is needed
+    container = document.querySelector(extension.searchEngine.endlessScrolling.container);
+    //Observe the number of childnodes of container and the number of items
+    //in known_results.items. If they aren't the same, reload the navigation 
+    const config = { attributes: false, childList: true, subtree: false };
+    let first_obversation = true;
+    const observer = new MutationObserver((mutationsList, observer) => {
+      if (first_obversation && this.known_results){
+        this.observedAdditions = this.known_results.items.length
+        first_obversation = false;
+      }
+      this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
+      if(this.known_results && this.known_results.items.length < this.observedAdditions){
+        loadOptions.then(() => this.initResultsNavigation());
+      }
+    })
+    observer.observe(container, config)
+  
+
   }
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -190,7 +190,7 @@ Object.assign(extension, {
       if(observed_href && observed_href != location.href){
         //Mutation Server was triggered due too loading a new url -> disconnect the observer
         observer.disconnect();
-        startExt();
+        startExtension();
         return; 
       }
       this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
@@ -383,7 +383,7 @@ const sleep = (milliseconds) => {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
-const startExt = () => {
+const startExtension = () => {
   const loadOptions = extension.options.load();
   
   // Entry Point
@@ -397,4 +397,4 @@ const startExt = () => {
   })
 }
 
-startExt();
+startExtension();

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ Object.assign(extension, {
   
   init(loadOptions) {
     if(extension.searchEngine.endlessScrolling){
-      this.supportEndlessScrolling()
+      this.supportEndlessScrolling(extension.searchEngine.endlessScrolling.container)
     }
     if (extension.searchEngine.canInit()) {
       loadOptions.then(() => this.initResultsNavigation());
@@ -169,11 +169,16 @@ Object.assign(extension, {
       }
     });
   },
-  supportEndlessScrolling(){
-    //The search engine uses endless scrolling, so a Mutationobserver is needed
-    container = document.querySelector(extension.searchEngine.endlessScrolling.container);
-    //Observe the number of childnodes of container and the number of items
-    //in known_results.items. If they aren't the same, reload the navigation 
+  /**
+   * Observes the number of childnodes of container_selector
+   * and compares them with this.known_results.items. Automatically
+   * inits a reload of the navigation when they don't match up. This 
+   * ensures that all search_links are always up to date when scrolling.
+   * 
+   * @param {String} container_selector 
+   */
+  supportEndlessScrolling(container_selector){
+    container = document.querySelector(container_selector);
     const config = { attributes: false, childList: true, subtree: false };
     let first_obversation = true;
     const observer = new MutationObserver((mutationsList, observer) => {

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ Object.assign(extension, {
       loadOptions.then(() => this.initResultsNavigation());
     }
     loadOptions.then(() => this.initCommonSearchNavigation());
-    
   },
   /**
    * Gets the element to activate upon navigation. The focused element in the document is preferred (if there is one)
@@ -188,6 +187,7 @@ Object.assign(extension, {
       }
       this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
       if(this.known_results && this.known_results.items.length < this.observedAdditions){
+        //Initialize a reload of navigation, save local values 
         this.options.local.values.lastQueryUrl = location.href;
         this.options.local.values.lastFocusedIndex = this.known_results.focusedIndex;
         extension.options.local.save().then(()=>{
@@ -197,8 +197,6 @@ Object.assign(extension, {
       }
     })
     observer.observe(container, config)
-  
-
   }
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -189,6 +189,7 @@ Object.assign(extension, {
       this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
       if(this.known_results && this.known_results.items.length < this.observedAdditions){
         loadOptions.then(() => this.initResultsNavigation());
+        loadOptions.then(() => this.initCommonSearchNavigation());
       }
     })
     observer.observe(container, config)

--- a/src/main.js
+++ b/src/main.js
@@ -188,8 +188,12 @@ Object.assign(extension, {
       }
       this.observedAdditions = this.observedAdditions + mutationsList[0].addedNodes.length;
       if(this.known_results && this.known_results.items.length < this.observedAdditions){
-        loadOptions.then(() => this.initResultsNavigation());
-        loadOptions.then(() => this.initCommonSearchNavigation());
+        this.options.local.values.lastQueryUrl = location.href;
+        this.options.local.values.lastFocusedIndex = this.known_results.focusedIndex;
+        extension.options.local.save().then(()=>{
+          loadOptions.then(() => this.initResultsNavigation());
+          loadOptions.then(() => this.initCommonSearchNavigation());
+        })
       }
     })
     observer.observe(container, config)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -239,7 +239,8 @@
                 "*://www.google.co.zm/search*",
                 "*://www.google.co.zw/search*",
                 "*://www.google.cat/search*",
-                "*://encrypted.google.com/*"
+                "*://encrypted.google.com/*",
+                "*://www.youtube.com/*"
             ]
         }
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "permissions": ["storage"],
     "optional_permissions": [
         "http://*/*",
-        "https://*/*" 
+        "https://*/*"
     ],
     "options_page": "options.html",
     "options_ui": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "permissions": ["storage"],
     "optional_permissions": [
         "http://*/*",
-        "https://*/*"
+        "https://*/*" 
     ],
     "options_page": "options.html",
     "options_ui": {
@@ -239,8 +239,7 @@
                 "*://www.google.co.zm/search*",
                 "*://www.google.co.zw/search*",
                 "*://www.google.cat/search*",
-                "*://encrypted.google.com/*",
-                "*://www.youtube.com/*"
+                "*://encrypted.google.com/*"
             ]
         }
     ]

--- a/src/options.html
+++ b/src/options.html
@@ -31,6 +31,7 @@
         <h3>Search engines</h3>
         <div class="option">
             <input type="checkbox" id="startpage" name="startpage">Add startpage</input>
+            <input type="checkbox" id="youtube" name="youtube">Add Youtube</input>
         </div>
     </div>
     <div id="keybindings-container">

--- a/src/options.js
+++ b/src/options.js
@@ -37,6 +37,7 @@ const divToOptionName = {
 };
 
 const startpage = document.getElementById('startpage');
+const youtube = document.getElementById("youtube")
 
 // Saves options to chrome.storage.sync.
 const saveOptions = () => {
@@ -47,6 +48,7 @@ const saveOptions = () => {
   extension.options.sync.values.hideOutline = document.getElementById('hide-outline').checked
   extension.options.sync.values.delay = document.getElementById('delay').value
   extension.options.sync.values.searchEngines.startpage = startpage.checked;
+  extension.options.sync.values.searchEngines.youtube = youtube.checked;
 
   // Save options from divs.
   for(let key in divToOptionName) {
@@ -75,6 +77,7 @@ const restoreOptions = () => {
     document.getElementById('hide-outline').checked = extension.options.sync.values.hideOutline;
     document.getElementById('delay').value = extension.options.sync.values.delay;
     startpage.checked = extension.options.sync.values.searchEngines.startpage;
+    youtube.checked = extension.options.sync.values.searchEngines.youtube;
 
     // Restore options from divs.
     for(let key in divToOptionName) {
@@ -93,6 +96,10 @@ document.getElementById('save').addEventListener('click', saveOptions);
 startpage.addEventListener('change', () => {
   addSearchEnginePermission(startpage);
 });
+
+youtube.addEventListener("change", () => {
+  addSearchEnginePermission(youtube);
+})
 
 /**
  * Add other search engines domain on user input

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -230,6 +230,9 @@ const searchEngines = [
                 [document.querySelectorAll("ytd-channel-renderer > a"), null]
             ],[])
         },
+        endlessScrolling: {
+            container: "div#contents div#contents"
+        },
         changeTools(period){
 
         }

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -214,7 +214,6 @@ const searchEngines = [
         urlPattern: /^(www|encrypted)\.youtube\./,
         searchBoxSelector: 'input#search',
         HighlightClass: "youtube-focused-search-result",
-        HighlightedParentSelector: ["a.ytd-playlist-renderer, div#meta", "all"],
         tabs: [
             //Leave this empty for now
         ],
@@ -227,7 +226,7 @@ const searchEngines = [
                 //Playlists
                 [document.querySelectorAll("div#content a.ytd-playlist-renderer"), null],
                 //Channels
-                [document.querySelectorAll("ytd-channel-renderer > a"), null]
+                [document.querySelectorAll("div#info.ytd-channel-renderer"), null]
             ],[])
         },
         endlessScrolling: {

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -224,6 +224,8 @@ const searchEngines = [
                 ],
                 //Playlists
                 [document.querySelectorAll("div#content a.ytd-playlist-renderer"), null],
+                //Mixes
+                [document.querySelectorAll("div#content a.ytd-radio-renderer"), null],
                 //Channels
                 [document.querySelectorAll("div#info.ytd-channel-renderer"), null]
             ],[])

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -210,7 +210,7 @@ const searchEngines = [
         canInit(){
             return true;
         }, 
-        urlPattern: /^(www|encrypted)\.youtube\./,
+        urlPattern: /^(www)\.youtube\./,
         searchBoxSelector: 'input#search',
         HighlightClass: "youtube-focused-search-result",
         tabs: [

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -207,12 +207,14 @@ const searchEngines = [
         }
     },
     {
+        name: "Youtube",
         canInit(){
             return true;
         }, 
         urlPattern: /^(www|encrypted)\.youtube\./,
         searchBoxSelector: 'input#search',
         HighlightClass: "youtube-focused-search-result",
+        HighlightedParentSelector: ["a.ytd-playlist-renderer, div#meta", "all"],
         tabs: [
             //Leave this empty for now
         ],

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -207,7 +207,6 @@ const searchEngines = [
         }
     },
     {
-        name: "Youtube",
         canInit(){
             return true;
         }, 
@@ -233,9 +232,12 @@ const searchEngines = [
             container: "div#contents div#contents"
         },
         changeTools(period){
-            let toggle_btn = document.querySelectorAll("a.ytd-toggle-button-renderer")[0];
-            toggle_btn.click();
-            toggle_btn.click();
+            if(!document.querySelector("div#collapse-content")){
+                let toggle_btn = document.querySelectorAll("a.ytd-toggle-button-renderer")[0];
+                //Toggling the buttons ensures that div#collapse-content is loaded 
+                toggle_btn.click();
+                toggle_btn.click();
+            }
             let forms = document.querySelectorAll("div#collapse-content > *:first-of-type ytd-search-filter-renderer")
             let neededForm = null;
             switch(period){

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -205,6 +205,33 @@ const searchEngines = [
                     break;
             }
         }
+    },
+    {
+        canInit(){
+            return true;
+        }, 
+        urlPattern: /^(www|encrypted)\.youtube\./,
+        searchBoxSelector: 'input#search',
+        HighlightClass: "youtube-focused-search-result",
+        tabs: [
+            //Leave this empty for now
+        ],
+        getSearchLinks() {
+            return new SearchResultCollection([
+                //Videos
+                [document.querySelectorAll("#title-wrapper h3 a#video-title"),
+                n => n.parentElement.parentElement
+                ],
+                //Playlists
+                [document.querySelectorAll("div#content a.ytd-playlist-renderer"), null],
+                //Channels
+                [document.querySelectorAll("ytd-channel-renderer > a"), null]
+            ],[])
+        },
+        changeTools(period){
+
+        }
+
     }
 ]
 

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -234,7 +234,31 @@ const searchEngines = [
             container: "div#contents div#contents"
         },
         changeTools(period){
-
+            let toggle_btn = document.querySelectorAll("a.ytd-toggle-button-renderer")[0];
+            toggle_btn.click();
+            toggle_btn.click();
+            let forms = document.querySelectorAll("div#collapse-content > *:first-of-type ytd-search-filter-renderer")
+            let neededForm = null;
+            switch(period){
+                case "h": 
+                    neededForm = forms[0];
+                    break;
+                case "d":
+                    neededForm = forms[1];
+                    break;
+                case "w":
+                    neededForm = forms[2];
+                    break;
+                case "m":
+                    neededForm = forms[3];
+                    break;
+                case "y":
+                    neededForm = forms[4];
+                    break;
+            }
+            if(neededForm){
+                neededForm.childNodes[1].click()
+            }
         }
 
     }

--- a/src/search_results.css
+++ b/src/search_results.css
@@ -12,6 +12,13 @@
     border-radius: 9px;
 }
 
+.youtube-focused-search-result{
+  border-color: #c4302b!important;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 2px;
+}
+
 .no-outline,
 .no-outline:focus  {
   outline: none;


### PR DESCRIPTION
I added Youtube to the supported Websites for this extension.

## Additions

I added Youtube to searchEngines.js. Thanks for the restructuring @Gazorby, it would have been way harder with out your additions. I also added Youtube to the Options Page and I found an issue doing it. Even though the page suggest it, there is no way to take away permissions from search engine websites. I will create a separate issue for this. 

Since Youtube uses endless scrolling, I had to change main.js quite a bit to support it. I used a MutationObserver that watches a container, specifiable in searchEngines.js, which basically reloads main.js when it detects any changes. There is some ugly cross referencing with this.known_results, which I want to change later. 