### PR TITLE
Update Microsoft Edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Browser extension that adds configurable keyboard shortcuts to Google search, Yo
 ## Features
 
 - Lightweight
-- Supports Chrome, Firefox, and pre-Chromium Edge
+- Supports Chrome, Firefox, and Edge
 - Extensive Google keyboard shortcuts including:
   - Selecting results
   - Opening results in the background or foreground
@@ -62,7 +62,7 @@ Install from the [Add-ons for Firefox](https://addons.mozilla.org/firefox/addon/
 
 ### Edge
 
-Install from the [Microsoft Store](https://www.microsoft.com/store/apps/9P0PTV58KND9).
+Install from [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/inkjbmhmeghalgpacijccmbmbclkjgop).
 
 ## Keybindings
 


### PR DESCRIPTION
The old URL in the README was already redirecting to the new Microsoft Edge Add-ons page. The extension is already available there for the new Chromium-based version of Microsoft Edge.

In this PR the URL is updated to the new format and the `pre-Chromium Edge` statement has been dropped. 

*P.S. I just submitted the newest version of this extension to the Microsoft Store, which is currently undergoing review.*