### PR TITLE
feat: add brave search engine support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -238,6 +238,7 @@
         }
     ],
     "optional_permissions": [
+        "https://search.brave.com/*",
         "https://startpage.com/*",
         "https://www.startpage.com/*",
         "https://www.youtube.com/*",

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,7 @@ const DEFAULT_CSS = `/* NOTE:
 
 .wsn-google-focused-link::before,
 .wsn-google-focused-map::before,
+.wsn-brave-search-focused-link::before,
 .wsn-startpage-focused-link::before {
     content: "\u25BA";
     margin-right: 25px;
@@ -16,12 +17,24 @@ const DEFAULT_CSS = `/* NOTE:
     position: absolute;
 }
 
+.wsn-brave-search-focused-news {
+  position: relative;
+}
+
+.wsn-brave-search-focused-news::before {
+  content: "\u25BA";
+  top: 5px;
+  left: -45px;
+  position: absolute;
+}
+
 .wsn-google-focused-image {
     /* Images are less visible with a thin outline, so we use 2px here */
     outline: 2px solid black !important;
 }
 
-.wsn-google-focused-card {
+.wsn-google-focused-card,
+.wsn-brave-search-focused-card {
     border: 1px solid black !important;
 }
 

--- a/src/options_page.html
+++ b/src/options_page.html
@@ -199,6 +199,11 @@
             When you enable a website, the browser will prompt you for additional permissions which are needed to be able to run this extension on that website.
         </details>
         <div class="option">
+            <label for="brave-search">
+                <input type="checkbox" id="brave-search"> Enable on Brave Search
+            </label>
+        </div>
+        <div class="option">
             <label for="startpage">
                 <input type="checkbox" id="startpage"> Enable on Startpage
             </label>

--- a/src/options_page.js
+++ b/src/options_page.js
@@ -53,6 +53,7 @@ const generateURLPatterns = (prefix, domains, suffix) => {
 
 // Authorized urls for compatible search engines
 const OPTIONAL_PERMISSIONS_URLS = {
+  'brave-search': ['https://search.brave.com/*'],
   'startpage': [
     // It used to be 'https://www.startpage.com/*/*search*' but when requesting
     // this URL chrome actually grants permission to the URL below. This
@@ -120,6 +121,10 @@ const setSearchEnginePermission_ = async (checkbox) => {
 class OptionsPageManager {
   async init() {
     await this.loadOptions();
+    const braveSearch = document.getElementById('brave-search');
+    braveSearch.addEventListener('change', () => {
+      setSearchEnginePermission_(braveSearch);
+    });
     const startpage = document.getElementById('startpage');
     startpage.addEventListener('change', () => {
       setSearchEnginePermission_(startpage);
@@ -208,6 +213,10 @@ class OptionsPageManager {
 
   loadSearchEnginePermissions_(permissions) {
     // Check what URLs we have permission for.
+    const braveSearch = document.getElementById('brave-search');
+    braveSearch.checked = OPTIONAL_PERMISSIONS_URLS['brave-search'].every((url) => {
+      return permissions.origins.includes(url);
+    });
     const startpage = document.getElementById('startpage');
     startpage.checked = OPTIONAL_PERMISSIONS_URLS['startpage'].every((url) => {
       return permissions.origins.includes(url);


### PR DESCRIPTION
Adds support for Brave Search engine.

Implemented features
- [x] Web
- [x] News
- [x] Videos
- [x] `Esc` to focus on search box

Images tab wasn't implemented because there is already a built-in navigation feature.

https://github.com/infokiller/web-search-navigator/issues/292