### PR TITLE
fix(default style): focus cursor is not displayed

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -6,6 +6,10 @@ const DEFAULT_CSS = `/* NOTE:
  *   border can move other elements, for example the page numbers are moved in
  *   Google Scholar when highlighting the prev/next buttons.
  */
+ 
+.wsn-google-focused-link {
+    position: relative;
+}
 
 .wsn-google-focused-link::before,
 .wsn-google-focused-map::before,


### PR DESCRIPTION
Google search results have different DOM trees for each account. In some cases the focus cursor does not appear.

**User A:**
root dom have relative. so the focus cursor is displayed. ✅ 

<img width="1246" alt="スクリーンショット 2021-12-11 15 26 36" src="https://user-images.githubusercontent.com/5842851/145667307-9c09d963-6660-46bd-bc08-cd497757c5ec.png">

**User B:**
no relative. so the focus cursor does not appear. 🚫 

<img width="1142" alt="スクリーンショット 2021-12-11 15 29 00" src="https://user-images.githubusercontent.com/5842851/145667308-0d95826d-fc4c-4df0-93e3-4c820a2c95bf.png">

## Note

All accounts are in their initial state and are not affected by other extensions or design settings.
Account B is an organizational account, so that may have an impact.

The point is whether there is a `gxMns` class in the root DOM.

---

Thanks for your support