### PR TITLE
Added bottom margin fix for google search

### DIFF
--- a/src/search_engines.js
+++ b/src/search_engines.js
@@ -176,6 +176,9 @@ class GoogleSearch {
         element,
     );
   }
+  getBottomMargin(element) {
+    return isFirefox() ? 0 : getDefaultBottomMargin();
+  }
   onChangedResults(callback) {
     if (this.isImagesTab_()) {
       return this.onImageSearchResults_(callback);


### PR DESCRIPTION
As discussed in #219 for startpage, I also ran into this issue with google search on firefox, hence took the liberty of copying the previous fix to `GoogleSearch` as well

BugDemo - (_quick fix was to just scroll a little bit_)

https://user-images.githubusercontent.com/57226514/155869255-c823de88-f8d2-493d-b371-719d9c46ca65.mp4

It is hard to find queries to reproduce the bug. As discussed in the previous issue, it also depends on resolution of window. Hence here is a _before_ and _after_ of one that worked on my machine.

https://user-images.githubusercontent.com/57226514/155869559-92619406-148c-4393-9c45-8dca73fea213.mp4


