### PR TITLE
Enhancement: 4-key navigation on Youtube home page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,6 +146,33 @@ class SearchResultsManager {
       window.scrollTo(window.scrollX, 0);
     }
   }
+
+  focusDown(shouldWrap) {
+    const focusedRowIndex = this.focusedIndex % this.searchResults.itemsPerRow;
+    if (
+      this.focusedIndex + this.searchResults.itemsPerRow <
+      this.searchResults.length - 1
+    ) {
+      this.focus(this.focusedIndex + this.searchResults.itemsPerRow);
+    } else if (shouldWrap) {
+      this.focus(focusedRowIndex);
+    }
+  }
+
+  focusUp(shouldWrap) {
+    const focusedRowIndex = this.focusedIndex % this.searchResults.itemsPerRow;
+    if ( this.focusedIndex - this.searchResults.itemsPerRow > -1 ) {
+      this.focus(this.focusedIndex - this.searchResults.itemsPerRow);
+    } else if (shouldWrap) {
+      this.focus(
+          this.searchResults - 1 -
+          this.searchResults.itemsPerRow +
+          focusedRowIndex,
+      );
+    } else {
+      window.scrollTo(window.scrollY, 0);
+    }
+  }
 }
 
 class WebSearchNavigator {
@@ -385,24 +412,63 @@ class WebSearchNavigator {
     const getOpt = (key) => {
       return this.options.sync.get(key);
     };
-    this.register(getOpt('nextKey'), () => {
-      if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-        this.resultsManager.focus(0);
-        this.isFirstNavigation = false;
-      } else {
-        this.resultsManager.focusNext(getOpt('wrapNavigation'));
-      }
-      return false;
-    });
-    this.register(getOpt('previousKey'), () => {
-      if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-        this.resultsManager.focus(0);
-        this.isFirstNavigation = false;
-      } else {
-        this.resultsManager.focusPrevious(getOpt('wrapNavigation'));
-      }
-      return false;
-    });
+    if (!this.searchEngine.gridNavigation) {
+      this.register(getOpt('nextKey'), () => {
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusNext(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+      this.register(getOpt('previousKey'), () => {
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusPrevious(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+    } else {
+      this.register(getOpt('nextKey'), () => { // down
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusDown(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+      this.register(getOpt('previousKey'), () => { // up
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusUp(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+      this.register(getOpt('navigatePreviousResultPage'), () => { // left
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusPrevious(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+      this.register(getOpt('navigateNextResultPage'), () => { // right
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          this.resultsManager.focusNext(getOpt('wrapNavigation'));
+        }
+        return false;
+      });
+    }
     this.register(getOpt('navigateKey'), () => {
       const link = this.resultsManager.getElementToNavigate();
       if (link == null) {

--- a/src/main.js
+++ b/src/main.js
@@ -414,62 +414,45 @@ class WebSearchNavigator {
     const getOpt = (key) => {
       return this.options.sync.get(key);
     };
+    const onFocusChange = (callback) => {
+      return () => {
+        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
+          this.resultsManager.focus(0);
+          this.isFirstNavigation = false;
+        } else {
+          const _callback = callback.bind(this.resultsManager);
+          _callback(getOpt('wrapNavigation'));
+        }
+        return false;
+      };
+    };
+
     if (!this.searchEngine.gridNavigation) {
-      this.register(getOpt('nextKey'), () => {
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusNext(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
-      this.register(getOpt('previousKey'), () => {
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusPrevious(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
+      this.register(
+          getOpt('nextKey'),
+          onFocusChange(this.resultsManager.focusNext),
+      );
+      this.register(
+          getOpt('previousKey'),
+          onFocusChange(this.resultsManager.focusPrevious),
+      );
     } else {
-      this.register(getOpt('nextKey'), () => { // down
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusDown(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
-      this.register(getOpt('previousKey'), () => { // up
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusUp(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
-      this.register(getOpt('navigatePreviousResultPage'), () => { // left
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusPrevious(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
-      this.register(getOpt('navigateNextResultPage'), () => { // right
-        if (!getOpt('autoSelectFirst') && this.isFirstNavigation) {
-          this.resultsManager.focus(0);
-          this.isFirstNavigation = false;
-        } else {
-          this.resultsManager.focusNext(getOpt('wrapNavigation'));
-        }
-        return false;
-      });
+      this.register(
+          getOpt('nextKey'),
+          onFocusChange(this.resultsManager.focusDown),
+      );
+      this.register(
+          getOpt('previousKey'),
+          onFocusChange(this.resultsManager.focusUp),
+      );
+      this.register( // left
+          getOpt('navigatePreviousResultPage'),
+          onFocusChange(this.resultsManager.focusPrevious),
+      );
+      this.register( // right
+          getOpt('navigateNextResultPage'),
+          onFocusChange(this.resultsManager.focusNext),
+      );
     }
     this.register(getOpt('navigateKey'), () => {
       const link = this.resultsManager.getElementToNavigate();

--- a/src/main.js
+++ b/src/main.js
@@ -148,22 +148,24 @@ class SearchResultsManager {
   }
 
   focusDown(shouldWrap) {
-    const focusedRowIndex = this.focusedIndex % this.searchResults.itemsPerRow;
     if (
       this.focusedIndex + this.searchResults.itemsPerRow <
       this.searchResults.length - 1
     ) {
       this.focus(this.focusedIndex + this.searchResults.itemsPerRow);
     } else if (shouldWrap) {
+      const focusedRowIndex = this.focusedIndex %
+        this.searchResults.itemsPerRow;
       this.focus(focusedRowIndex);
     }
   }
 
   focusUp(shouldWrap) {
-    const focusedRowIndex = this.focusedIndex % this.searchResults.itemsPerRow;
     if ( this.focusedIndex - this.searchResults.itemsPerRow > -1 ) {
       this.focus(this.focusedIndex - this.searchResults.itemsPerRow);
     } else if (shouldWrap) {
+      const focusedRowIndex = this.focusedIndex %
+        this.searchResults.itemsPerRow;
       this.focus(
           this.searchResults - 1 -
           this.searchResults.itemsPerRow +

--- a/src/search_engines.js
+++ b/src/search_engines.js
@@ -113,6 +113,9 @@ const getSortedSearchResults = (
         searchResults.push(searchResult);
       }
     }
+    if (results.gridNavigation && results.gridNavigation.itemsPerRow) {
+      searchResults.itemsPerRow = results.gridNavigation.itemsPerRow;
+    }
   }
   // Sort searchResults by their document position.
   searchResults.sort((a, b) => {
@@ -840,6 +843,7 @@ class StartPage {
 class YouTube {
   constructor(options) {
     this.options = options;
+    this.gridNavigation = false;
   }
   get urlPattern() {
     return /^https:\/\/(www)\.youtube\./;
@@ -931,6 +935,10 @@ class YouTube {
         highlightClass: 'wsn-youtube-focused-video',
         highlightedElementSelector: (n) => n.closest('ytd-rich-item-renderer'),
         containerSelector: (n) => n.closest('ytd-rich-item-renderer'),
+        gridNavigation: {
+          itemsPerRow: document.querySelector('ytd-rich-grid-row')
+              .getElementsByTagName('ytd-rich-item-renderer').length,
+        },
       },
       // Playlists
       {
@@ -955,6 +963,11 @@ class YouTube {
         containerSelector: (n) => n.closest('ytd-grid-video-renderer'),
       },
     ];
+
+    // checking if homepage results are present
+    if (includedElements[2].nodes.length > 0) {
+      this.gridNavigation = true;
+    }
     return getSortedSearchResults(includedElements, []);
   }
 

--- a/src/search_engines.js
+++ b/src/search_engines.js
@@ -927,19 +927,6 @@ class YouTube {
         highlightedElementSelector: (n) => n.closest('ytd-playlist-renderer'),
         containerSelector: (n) => n.closest('ytd-playlist-renderer'),
       },
-      // Home page lists
-      {
-        nodes: document.querySelectorAll(
-            'ytd-rich-item-renderer a#video-title-link',
-        ),
-        highlightClass: 'wsn-youtube-focused-video',
-        highlightedElementSelector: (n) => n.closest('ytd-rich-item-renderer'),
-        containerSelector: (n) => n.closest('ytd-rich-item-renderer'),
-        gridNavigation: {
-          itemsPerRow: document.querySelector('ytd-rich-grid-row')
-              .getElementsByTagName('ytd-rich-item-renderer').length,
-        },
-      },
       // Playlists
       {
         nodes: document.querySelectorAll('a.ytd-playlist-video-renderer'),
@@ -963,12 +950,23 @@ class YouTube {
         containerSelector: (n) => n.closest('ytd-grid-video-renderer'),
       },
     ];
-
     // checking if homepage results are present
-    if (includedElements[2].nodes.length > 0) {
+    const homePageElements = {
+      nodes: document.querySelectorAll(
+          'ytd-rich-item-renderer a#video-title-link',
+      ),
+      highlightClass: 'wsn-youtube-focused-video',
+      highlightedElementSelector: (n) => n.closest('ytd-rich-item-renderer'),
+      containerSelector: (n) => n.closest('ytd-rich-item-renderer'),
+      gridNavigation: {
+        itemsPerRow: document.querySelector('ytd-rich-grid-row')
+            .getElementsByTagName('ytd-rich-item-renderer').length,
+      },
+    };
+    if (homePageElements.nodes.length > 0) {
       this.gridNavigation = true;
     }
-    return getSortedSearchResults(includedElements, []);
+    return getSortedSearchResults([...includedElements, homePageElements], []);
   }
 
   changeTools(period) {


### PR DESCRIPTION
Right now we can only use the up and down keys to navigate through the recommended results on the youtube home page.
Would be nice if I could use the left and right keys as well.

This seemed possible because the left and right arrows are reserved for the `navigatePreviousResultPage` and `navigateNextResultPage` option respectively. Since there are no result pages on youtube but just endless scrolling these could instead be used inside `SearchResultsManager` for up and down navigation.

> This is just a quick and dirty attempt, LMK about the required changes