### PR TITLE
Remove deprecated "options_page"

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,7 +16,6 @@
         }
     },
     "permissions": ["storage"],
-    "options_page": "options_page.html",
     "options_ui": {
         "page": "options_page.html",
         "chrome_style": true


### PR DESCRIPTION
Reading manifest: Warning processing options_page: An unexpected property was found in the WebExtension manifest. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page