### PR TITLE
feat: copy URL of focus

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -586,6 +586,19 @@ class WebSearchNavigator {
       });
       return false;
     });
+    this.register(getOpt('copyUrlKey'), () => {
+      const link = this.resultsManager.getElementToNavigate();
+      if (
+        link == null || link.localName !== 'a' || !link.href ||
+        !navigator.clipboard
+      ) {
+        return true;
+      }
+      navigator.clipboard.writeText(link.href).then(
+        () => false,
+        (err) => true,
+      );
+    });
   }
 
   initChangeToolsNavigation() {

--- a/src/main.js
+++ b/src/main.js
@@ -595,8 +595,8 @@ class WebSearchNavigator {
         return true;
       }
       navigator.clipboard.writeText(link.href).then(
-        () => false,
-        (err) => true,
+          () => false,
+          (err) => true,
       );
     });
   }

--- a/src/options.js
+++ b/src/options.js
@@ -152,7 +152,7 @@ const DEFAULT_KEYBINDINGS = {
   showImagesLarge: ['z l'],
   showImagesMedium: ['z e'],
   showImagesIcon: ['z i'],
-  copyUrlKey: ['c', 'y'],
+  copyUrlKey: [],
 };
 
 const DEFAULT_OPTIONS = {

--- a/src/options.js
+++ b/src/options.js
@@ -152,6 +152,7 @@ const DEFAULT_KEYBINDINGS = {
   showImagesLarge: ['z l'],
   showImagesMedium: ['z e'],
   showImagesIcon: ['z i'],
+  copyUrlKey: ['c', 'y'],
 };
 
 const DEFAULT_OPTIONS = {

--- a/src/options_page.html
+++ b/src/options_page.html
@@ -103,7 +103,7 @@
             </div>
             <div class="option">
               <label for="copy-url-key" class="option-desc">Copy URL of focus</label>
-              <input id="copy-url-key" class="input-keybinding" type="text" value="c, y">
+              <input id="copy-url-key" class="input-keybinding" type="text" value="">
             </div>
         </details>
         <details>

--- a/src/options_page.html
+++ b/src/options_page.html
@@ -101,6 +101,10 @@
                 <label for="navigate-previous-result-page" class="option-desc">Previous page</label>
                 <input id="navigate-previous-result-page" class="input-keybinding" type="text" value="left">
             </div>
+            <div class="option">
+              <label for="copy-url-key" class="option-desc">Copy URL of focus</label>
+              <input id="copy-url-key" class="input-keybinding" type="text" value="c, y">
+            </div>
         </details>
         <details>
             <summary><h3>Results filtering</h3></summary>

--- a/src/options_page.js
+++ b/src/options_page.js
@@ -103,6 +103,7 @@ const KEYBINDING_TO_DIV = {
   showImagesLarge: 'show-images-large',
   showImagesMedium: 'show-images-medium',
   showImagesIcon: 'show-images-icon',
+  copyUrlKey: 'copy-url-key',
 };
 
 /**


### PR DESCRIPTION
This works on list-based pages such as "All", "Videos", "News", etc.
It doesn't work for the "Image" page.

See also: #549 #570