### PR TITLE
Enable opening Google Images tab

### DIFF
--- a/src/search_engines.js
+++ b/src/search_engines.js
@@ -229,7 +229,7 @@ class GoogleSearch {
 
   static #isImagesTab() {
     const searchParams = new URLSearchParams(window.location.search);
-    return searchParams.get('tbm') === 'isch';
+    return searchParams.get('udm') === '2';
   }
 
   static #getImagesTabResults() {
@@ -618,7 +618,7 @@ class GoogleSearch {
           // eslint-disable-next-line max-len
           'a[href*="/search?q="]:not([href*="&tbm="]):not([href*="maps.google."])',
       ),
-      navigateImagesTab: selectorElementGetter('a[href*="&tbm=isch"]'),
+      navigateImagesTab: selectorElementGetter('a[href*="&udm=2"]'),
       navigateVideosTab: selectorElementGetter('a[href*="&tbm=vid"]'),
       navigateMapsTab: selectorElementGetter('a[href*="maps.google."]'),
       navigateNewsTab: selectorElementGetter('a[href*="&tbm=nws"]'),

--- a/src/search_engines.js
+++ b/src/search_engines.js
@@ -553,7 +553,9 @@ class GoogleSearch {
   }
 
   static #imageSearchTabs() {
-    const visibleTabs = document.querySelectorAll('.T47uwc > a');
+    const visibleTabs = document.querySelectorAll(
+        '.crJ18e div[role="listitem"] > a',
+    );
     // NOTE: The order of the tabs after the first two is dependent on the
     // query. For example:
     // - "cats": videos, news, maps
@@ -562,21 +564,25 @@ class GoogleSearch {
     return {
       navigateSearchTab: visibleTabs[0],
       navigateMapsTab: selectorElementGetter(
-          '.T47uwc > a[href*="maps.google."]',
+          '.crJ18e div[role="listitem"] > a[href*="maps.google."]',
       ),
-      navigateVideosTab: selectorElementGetter('.T47uwc > a[href*="&tbm=vid"]'),
-      navigateNewsTab: selectorElementGetter('.T47uwc > a[href*="&tbm=nws"]'),
+      navigateVideosTab: selectorElementGetter(
+          '.crJ18e div[role="listitem"] > a[href*="&tbm=vid"]',
+      ),
+      navigateNewsTab: selectorElementGetter(
+          '.crJ18e div[role="listitem"] > a[href*="&tbm=nws"]',
+      ),
       navigateShoppingTab: selectorElementGetter(
-          'a[role="menuitem"][href*="&tbm=shop"]',
+          'a[role="link"][href*="&tbm=shop"]',
       ),
       navigateBooksTab: selectorElementGetter(
-          'a[role="menuitem"][href*="&tbm=bks"]',
+          'a[role="link"][href*="&tbm=bks"]',
       ),
       navigateFlightsTab: selectorElementGetter(
-          'a[role="menuitem"][href*="&tbm=flm"]',
+          'a[role="link"][href*="&tbm=flm"]',
       ),
       navigateFinancialTab: selectorElementGetter(
-          'a[role="menuitem"][href*="/finance?"]',
+          'a[role="link"][href*="/finance?"]',
       ),
       // TODO: Disable image search's default keybindings to avoid confusing the
       // user, because the default keybindings can cause an indenepdent


### PR DESCRIPTION
This PR addresses the functionality to open Google Images tab and other tabs in the Google Images page, adapting to recent changes in Google's URL structure and page layout.

## Related Issues
- Fixes #576
- Fixes #594

## Changes
1. Updated the selector for the Google Images tab to accommodate Google's URL structure change
2. Updated selectors for other tabs in the Google Images page

## Reason for Changes

### Google Images Tab
Google recently changed the URL structure for Google Images, removing the `tbm=isch` parameter that was previously used to identify image search results. This change broke our existing functionality for opening the Google Images tab.

#### Technical Details
- Previously, we used the selector `'a[href*="&tbm=isch"]'` to identify the Google Images tab.
- With Google's changes, the `tbm` parameter is no longer present in the URL.
- We've identified that Google now uses `udm=2` in the URL for image search results.
- We've updated our selectors to use `udm=2` instead of `tbm=isch`.

### Other Tabs in Google Images Page
In addition to the URL structure change, Google also modified the selectors for other tabs in the Google Images page. This necessitated further updates to our codebase.

#### Technical Details
- The selectors for other tabs in the Google Images page were no longer valid.
- We've updated these selectors to match the new structure of the Google Images page.
- This ensures that users can navigate to other tabs (e.g., Videos, News) while browsing image search results.

## Implementation
1. Modified our code to use the new `udm=2` parameter to identify and interact with Google Images tabs.
2. Updated selectors for other tabs in the Google Images page to match Google's new page structure.

## References
- https://stackoverflow.com/questions/21530274/format-for-a-url-that-goes-to-google-image-search#comment138664058_21530382
- https://medium.com/@tanyongsheng0805/every-google-udm-in-the-world-6ee9741434c9